### PR TITLE
photos-to-sql not found?

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The sha256 hash of the photo contents will be used as the name of the file in th
 
 The `apple-photos` command imports metadata from your Apple Photos library.
 
-    $ photo-to-sqlite apple-photos photos.db
+    $ dogsheep-photos apple-photos photos.db
 
 Imported metadata includes places, people, albums, quality scores and machine learning labels for the photo contents.
 


### PR DESCRIPTION
I wonder if `photos-to-sql` is an old name for `dogsheep-photos`, because I can't find it anywhere.

I can't actually get this command to work (`sqlite3.OperationalError: no such table: attached.ZGENERICASSET` thrown) but I don't think that's related