### PR TITLE
Update cli.py - gcloud compatibility

### DIFF
--- a/dogsheep_photos/cli.py
+++ b/dogsheep_photos/cli.py
@@ -88,7 +88,7 @@ def upload(db_path, directories, auth, no_progress, dry_run):
     db = sqlite_utils.Database(db_path)
     client = boto3.client(
         "s3",
-        endpoint_url==creds["photos_s3_endpoint_url"],
+        endpoint_url=creds["photos_s3_endpoint_url"],
         aws_access_key_id=creds["photos_s3_access_key_id"],
         aws_secret_access_key=creds["photos_s3_secret_access_key"],
     )

--- a/dogsheep_photos/cli.py
+++ b/dogsheep_photos/cli.py
@@ -88,6 +88,7 @@ def upload(db_path, directories, auth, no_progress, dry_run):
     db = sqlite_utils.Database(db_path)
     client = boto3.client(
         "s3",
+        endpoint_url==creds["photos_s3_endpoint_url"],
         aws_access_key_id=creds["photos_s3_access_key_id"],
         aws_secret_access_key=creds["photos_s3_secret_access_key"],
     )


### PR DESCRIPTION
This is very useful tool, and since I want it to store my images in s3-compatible google storage bucket, I added this parameter to provide "https://storage.googleapis.com" as an endpoint url. Probably, should also update dogsheep-photos s3-auth command.

Also, as a side note, in order to find s3-compatible credentials from your gcloud, follow to this page: https://console.cloud.google.com/storage/settings;tab=interoperability

